### PR TITLE
Don't require tide features we don't directly need

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["web-programming::http-server", "web-programming"]
 async-tungstenite = "0.10.0"
 sha-1 = "0.9.2"
 base64 = "0.13.0"
-tide = "0.15.0"
+tide = { version = "0.15.0", default-features = false, features = ["h1-server"] }
 futures-util = "0.3.8"
 pin-project = "1.0.2"
 async-dup = "1.2.2"


### PR DESCRIPTION
This allows the user of tide-websockets to use tide without requiring
features like "sessions" or "cookies".