### PR TITLE
Update crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
 async-tungstenite = "0.22.2"
-sha-1 = "0.9.6"
+sha1 = "0.10.5"
 base64 = "0.21.0"
 tide = { version = "0.16.0", default-features = false, features = ["h1-server"] }
 futures-util = "0.3.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["tide", "websockets"]
 categories = ["web-programming::http-server", "web-programming"]
 
 [dependencies]
-async-tungstenite = "0.15.0"
+async-tungstenite = "0.22.2"
 sha-1 = "0.9.6"
 base64 = "0.13.0"
 tide = { version = "0.16.0", default-features = false, features = ["h1-server"] }
@@ -24,5 +24,5 @@ serde = "1.0.126"
 async-std = "1.9.0"
 
 [dev-dependencies]
-env_logger = "0.8.3"
+env_logger = "0.10.0"
 async-std = { version = "1.9.0", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tide-websockets"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Jacob Rothstein <hi@jbr.me>"]
 edition = "2018"
 description = "tide websockets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["web-programming::http-server", "web-programming"]
 [dependencies]
 async-tungstenite = "0.22.2"
 sha-1 = "0.9.6"
-base64 = "0.13.0"
+base64 = "0.21.0"
 tide = { version = "0.16.0", default-features = false, features = ["h1-server"] }
 futures-util = "0.3.15"
 pin-project = "1.0.7"

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -8,7 +8,7 @@ use crate::WebSocketConnection;
 use async_dup::Arc;
 use async_std::task;
 use base64::{prelude::BASE64_STANDARD, Engine};
-use sha1::{Digest, Sha1};
+use sha1::{digest::Update, Digest, Sha1};
 
 use tide::http::format_err;
 use tide::http::headers::{HeaderName, CONNECTION, UPGRADE};

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -7,6 +7,7 @@ use crate::WebSocketConnection;
 
 use async_dup::Arc;
 use async_std::task;
+use base64::{prelude::BASE64_STANDARD, Engine};
 use sha1::{Digest, Sha1};
 
 use tide::http::format_err;
@@ -169,7 +170,7 @@ where
         response.insert_header(UPGRADE, "websocket");
         response.insert_header(CONNECTION, "Upgrade");
         let hash = Sha1::new().chain(header).chain(WEBSOCKET_GUID).finalize();
-        response.insert_header("Sec-Websocket-Accept", base64::encode(&hash[..]));
+        response.insert_header("Sec-Websocket-Accept", BASE64_STANDARD.encode(&hash[..]));
         response.insert_header("Sec-Websocket-Version", "13");
 
         if let Some(protocol) = protocol {


### PR DESCRIPTION
- Upgrade `async-tungstenite` and `env_logger`
- Upgrade `base64` and update API usage
- Upgrade to `sha1` 0.10.5 and update API usage
